### PR TITLE
Upgraded to Angular2 2.0.0-alpha.46

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,4 +7,7 @@ logs
 tsd.d.ts
 typings
 
+/node_modules
+
 webpack.config.js
+

--- a/components/file-upload/file-drop.ts
+++ b/components/file-upload/file-drop.ts
@@ -18,7 +18,7 @@ import {FileUploader} from './file-uploader';
 })
 export class FileDrop {
   public uploader:FileUploader;
-  private fileOver:EventEmitter = new EventEmitter();
+  private fileOver:EventEmitter<any> = new EventEmitter();
 
   constructor(private element:ElementRef) {
   }

--- a/components/file-upload/file-uploader.ts
+++ b/components/file-upload/file-uploader.ts
@@ -77,7 +77,6 @@ export class FileUploader {
     }
 
     this.queue.splice(index, 1);
-    item._destroy();
     this.progress = this._getTotalProgress();
   }
 

--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
     "url": "https://github.com/valor-software/ng2-file-upload/issues"
   },
   "homepage": "https://github.com/valor-software/ng2-file-upload#readme",
-  "dependencies": {
-    "angular2": "2.0.0-alpha.44",
-    "ng2-bootstrap": "0.44.3",
+  "peerDependencies": {
+    "angular2": "2.0.0-alpha.46",
+    "ng2-bootstrap": "0.46.0",
     "reflect-metadata": "0.1.2",
-    "ts-loader": "0.5.6",
+    "@reactivex/rxjs": "5.0.0-alpha.7",
     "zone.js": "0.5.8"
   },
   "devDependencies": {
@@ -58,6 +58,7 @@
     "raw-loader": "0.5.1",
     "require-dir": "0.3.0",
     "typescript": "1.6.2",
+    "ts-loader": "0.5.6",
     "webpack": "1.12.2",
     "webpack-dev-server": "1.12.1"
   },


### PR DESCRIPTION
Added node_modules to .npmignore - node modules shouldn't be installed with npm and cause Typscript duplicate definition errors
Removed reference to _destroy in removeFromQueue (this was removed from the FileItem class but was still being called)
Put in required type for EventEmitter
Moved peer dependencies from dependencies to peer dependencies