### PR TITLE
Apply filter when add file to queue

### DIFF
--- a/components/file-upload/file-uploader.ts
+++ b/components/file-upload/file-uploader.ts
@@ -44,7 +44,7 @@ export class FileUploader {
     list.map(some => {
       let temp = new FileLikeObject(some);
 
-      if (this._isValidFile(temp, [], options)) {
+      if (this._isValidFile(temp, arrayOfFilters, options)) {
         let fileItem = new FileItem(this, some, options);
         addedFileItems.push(fileItem);
         this.queue.push(fileItem);

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "zone.js": "0.5.10",
     "es6-shim": "0.33.13",
     "bootstrap": "3.3.6",
-    "clean-webpack-plugin": "0.1.5",
+    "clean-webpack-plugin": "0.1.7",
     "compression-webpack-plugin": "0.2.0",
     "eslint": "1.10.3",
     "exports-loader": "0.6.2",


### PR DESCRIPTION
Filters were not being used when adding a file to the queue.  Updated to pass in arrayOfFilters instead of an empty array.