### PR TITLE
Effective default queue limit of 0

### DIFF
--- a/components/file-upload/file-uploader.ts
+++ b/components/file-upload/file-uploader.ts
@@ -225,7 +225,7 @@ export class FileUploader {
   }
 
   private _queueLimitFilter() {
-    return this.queue.length < this.queueLimit;
+    return this.queueLimit === undefined || this.queue.length < this.queueLimit;
   }
 
   private _isValidFile(file:any, filters:any, options:any) {


### PR DESCRIPTION
If you don't set the queueLimit manually, then it's undefined, so the queueLimitFilter never allows any files by default. I modified the filter to ignore the queueLimit if it's undefined.