### PR TITLE
Add option to specify queue limit

### DIFF
--- a/components/file-upload/file-uploader.ts
+++ b/components/file-upload/file-uploader.ts
@@ -23,12 +23,13 @@ export class FileUploader {
   public filters:Array<any> = [];
   private _failFilterIndex:number;
 
-  constructor(public options:any) {
+  constructor(public options:any, public qLimit?:any) {
     // Object.assign(this, options);
     this.url = options.url;
     this.authToken = options.authToken;
     this.filters.unshift({name: 'queueLimit', fn: this._queueLimitFilter});
     this.filters.unshift({name: 'folder', fn: this._folderFilter});
+    qLimit ? this.queueLimit = qLimit.queueLimit : this.queueLimit = 0;
   }
 
   public addToQueue(files:any[], options:any, filters:any) {
@@ -225,7 +226,7 @@ export class FileUploader {
   }
 
   private _queueLimitFilter() {
-    return this.queue.length < this.queueLimit;
+    return this.queueLimit === 0 || this.queue.length < this.queueLimit;
   }
 
   private _isValidFile(file:any, filters:any, options:any) {


### PR DESCRIPTION
Pass extra optional arg to FileUploader:

`private uploader: FileUploader = new FileUploader({url: URL}, {queueLimit:20})`

If arg is not supplied then queuelimit defaults to '0', which is an unlimtied queue.