### PR TITLE
Create disableMultipart option in FileUploader

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ Follow me [![twitter](https://img.shields.io/twitter/follow/valorkin.svg?style=s
 
   - `uploader` - (`FileUploader`) - uploader object. See using in [demo](https://github.com/valor-software/ng2-file-upload/blob/master/demo/components/file-upload/simple-demo.ts)
 
-  Parameters that supported by this object:
+  Parameters supported by this object:
 
   1. `url` - URL of File Uploader's route
   2. `authToken` - Auth token that will be applied as 'Authorization' header during file send.
+  3. `disableMultipart` - If 'true', disable using a multipart form for file upload and instead stream the file. Some APIs (e.g. Amazon S3) may expect the file to be streamed rather than sent via a form. Defaults to false.
 
 ### Events
 

--- a/components/file-upload/readme.md
+++ b/components/file-upload/readme.md
@@ -20,10 +20,11 @@ import {FileSelectDirective, FileDropDirective, FileUploader} from 'ng2-file-upl
 
   - `uploader` - (`FileUploader`) - uploader object. See using in [demo](https://github.com/valor-software/ng2-file-upload/blob/master/demo/components/file-upload/simple-demo.ts)
 
-  Parameters that supported by this object:
+  Parameters supported by this object:
 
   1. `url` - URL of File Uploader's route
   2. `authToken` - auth token that will be applied as 'Authorization' header during file send.
+  3. `disableMultipart` - If 'true', disable using a multipart form for file upload and instead stream the file. Some APIs (e.g. Amazon S3) may expect the file to be streamed rather than sent via a form. Defaults to false.
 
 ## FileDrop API
 


### PR DESCRIPTION
Proposed fix for #223 , based on this PR to `angular-file-upload`: https://github.com/nervgh/angular-file-upload/pull/602

Allows you to optionally tell `FileUploader` to stream the file instead of using a multipart form.

Typescript usage example:

```
public uploader:FileUploader = new FileUploader({url: URL, disableMultipart: true});
```
