### PR TITLE
Fix #22: Unable to set form's "name" on file upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Follow me [![twitter](https://img.shields.io/twitter/follow/valorkin.svg?style=s
   1. `url` - URL of File Uploader's route
   2. `authToken` - Auth token that will be applied as 'Authorization' header during file send.
   3. `disableMultipart` - If 'true', disable using a multipart form for file upload and instead stream the file. Some APIs (e.g. Amazon S3) may expect the file to be streamed rather than sent via a form. Defaults to false.
+  4. `itemAlias` - item alias (form name redefenition)
 
 ### Events
 

--- a/components/file-upload/file-item.class.ts
+++ b/components/file-upload/file-item.class.ts
@@ -4,9 +4,9 @@ import { FileUploader, ParsedResponseHeaders, FileUploaderOptions } from './file
 export class FileItem {
   public file:FileLikeObject;
   public _file:File;
-  public alias:string = 'file';
+  public alias:string;
   public url:string = '/';
-  public method:string = 'POST';
+  public method:string;
   public headers:any = [];
   public withCredentials:boolean = true;
   public formData:any = [];
@@ -31,8 +31,9 @@ export class FileItem {
     this.options = options;
     this.file = new FileLikeObject(some);
     this._file = some;
-    if (uploader.options && uploader.options.method) {
-      this.method = uploader.options.method;
+    if (uploader.options) {
+      this.method = uploader.options.method || 'POST';
+      this.alias = uploader.options.itemAlias || 'file';
     }
     this.url = uploader.options.url;
   }

--- a/components/file-upload/file-uploader.class.ts
+++ b/components/file-upload/file-uploader.class.ts
@@ -29,6 +29,7 @@ export interface FileUploaderOptions {
   removeAfterUpload?:boolean;
   url?:string;
   disableMultipart?:boolean;
+  itemAlias?: string;
 }
 
 export class FileUploader {


### PR DESCRIPTION
Hi, added quick fix for selecting alias for item.

Original ticket: #22

Could be specified as uploader itemAlias parameter:

```
public uploader:FileUploader = new FileUploader({
    url: `${environment.API_BASE_URL}/api`,
    itemAlias: 'newname'
});
```
