### PR TITLE
angular ~2.0.1 stable release

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,18 +50,18 @@
   "homepage": "https://github.com/valor-software/ng2-file-upload#readme",
   "dependencies": {},
   "peerDependencies": {
-    "@angular/common": "2.0.0",
-    "@angular/compiler": "2.0.0",
-    "@angular/core": "2.0.0",
-    "@angular/forms": "2.0.0"
+    "@angular/common": "~2.0.1",
+    "@angular/compiler": "~2.0.1",
+    "@angular/core": "~2.0.1",
+    "@angular/forms": "~2.0.1"
   },
   "devDependencies": {
-    "@angular/common": "2.0.0",
-    "@angular/compiler": "2.0.0",
-    "@angular/core": "2.0.0",
-    "@angular/forms": "2.0.0",
-    "@angular/platform-browser": "2.0.0",
-    "@angular/platform-browser-dynamic": "2.0.0",
+    "@angular/common": "~2.0.1",
+    "@angular/compiler": "~2.0.1",
+    "@angular/core": "~2.0.1",
+    "@angular/forms": "~2.0.1",
+    "@angular/platform-browser": "~2.0.1",
+    "@angular/platform-browser-dynamic": "~2.0.1",
     "@types/jasmine": "2.2.34",
     "@types/node": "6.0.39",
     "@types/webpack": "1.12.34",


### PR DESCRIPTION
Fixes warnings when using 2.0.1

```
npm WARN ng2-file-upload@1.1.0 requires a peer of @angular/common@2.0.0 but none was installed.
npm WARN ng2-file-upload@1.1.0 requires a peer of @angular/compiler@2.0.0 but none was installed.
npm WARN ng2-file-upload@1.1.0 requires a peer of @angular/core@2.0.0 but none was installed.
npm WARN ng2-file-upload@1.1.0 requires a peer of @angular/forms@2.0.0 but none was installed.

```
