### PR TITLE
Allow to extend classes

### DIFF
--- a/components/file-upload/file-drop.directive.ts
+++ b/components/file-upload/file-drop.directive.ts
@@ -8,7 +8,7 @@ export class FileDropDirective {
   @Output() public fileOver:EventEmitter<any> = new EventEmitter();
   @Output() public onFileDrop:EventEmitter<File[]> = new EventEmitter<File[]>();
 
-  private element:ElementRef;
+  protected element:ElementRef;
 
   public constructor(element:ElementRef) {
     this.element = element;
@@ -59,16 +59,16 @@ export class FileDropDirective {
     this.fileOver.emit(false);
   }
 
-  private _getTransfer(event:any):any {
+  protected _getTransfer(event:any):any {
     return event.dataTransfer ? event.dataTransfer : event.originalEvent.dataTransfer; // jQuery fix;
   }
 
-  private _preventAndStop(event:any):any {
+  protected _preventAndStop(event:any):any {
     event.preventDefault();
     event.stopPropagation();
   }
 
-  private _haveFiles(types:any):any {
+  protected _haveFiles(types:any):any {
     if (!types) {
       return false;
     }

--- a/components/file-upload/file-item.class.ts
+++ b/components/file-upload/file-item.class.ts
@@ -21,9 +21,9 @@ export class FileItem {
   public _xhr:XMLHttpRequest;
   public _form:any;
 
-  private uploader:FileUploader;
-  private some:File;
-  private options:FileUploaderOptions;
+  protected uploader:FileUploader;
+  protected some:File;
+  protected options:FileUploaderOptions;
 
   public constructor(uploader:FileUploader, some:File, options:FileUploaderOptions) {
     this.uploader = uploader;

--- a/components/file-upload/file-select.directive.ts
+++ b/components/file-upload/file-select.directive.ts
@@ -8,7 +8,7 @@ import { FileUploader } from './file-uploader.class';
 export class FileSelectDirective {
   @Input() public uploader:FileUploader;
 
-  private element:ElementRef;
+  protected element:ElementRef;
 
   public constructor(element:ElementRef) {
     this.element = element;

--- a/components/file-upload/file-uploader.class.ts
+++ b/components/file-upload/file-uploader.class.ts
@@ -51,7 +51,7 @@ export class FileUploader {
     disableMultipart: false
   };
 
-  private _failFilterIndex:number;
+  protected _failFilterIndex:number;
 
   public constructor(options:FileUploaderOptions) {
     this.setOptions(options);
@@ -353,7 +353,7 @@ export class FileUploader {
     this._render();
   }
 
-  private _getTotalProgress(value:number = 0):number {
+  protected _getTotalProgress(value:number = 0):number {
     if (this.options.removeAfterUpload) {
       return value;
     }
@@ -364,7 +364,7 @@ export class FileUploader {
     return Math.round(uploaded * ratio + current);
   }
 
-  private _getFilters(filters:FilterFunction[]|string):FilterFunction[] {
+  protected _getFilters(filters:FilterFunction[]|string):FilterFunction[] {
     if (!filters) {
       return this.options.filters;
     }
@@ -379,20 +379,20 @@ export class FileUploader {
     return this.options.filters;
   }
 
-  private _render():any {
+  protected _render():any {
     return void 0;
     // todo: ?
   }
 
-  // private _folderFilter(item:FileItem):boolean {
+  // protected _folderFilter(item:FileItem):boolean {
   //   return !!(item.size || item.type);
   // }
 
-  private _queueLimitFilter():boolean {
+  protected _queueLimitFilter():boolean {
     return this.options.queueLimit === undefined || this.queue.length < this.options.queueLimit;
   }
 
-  private _isValidFile(file:FileLikeObject, filters:FilterFunction[], options:FileUploaderOptions):boolean {
+  protected _isValidFile(file:FileLikeObject, filters:FilterFunction[], options:FileUploaderOptions):boolean {
     this._failFilterIndex = -1;
     return !filters.length ? true : filters.every((filter:FilterFunction) => {
       this._failFilterIndex++;
@@ -400,12 +400,12 @@ export class FileUploader {
     });
   }
 
-  private _isSuccessCode(status:number):boolean {
+  protected _isSuccessCode(status:number):boolean {
     return (status >= 200 && status < 300) || status === 304;
   }
 
   /* tslint:disable */
-  private _transformResponse(response:string, headers:ParsedResponseHeaders):string {
+  protected _transformResponse(response:string, headers:ParsedResponseHeaders):string {
     // todo: ?
     /*var headersGetter = this._headersGetter(headers);
      forEach($http.defaults.transformResponse, (transformFn) => {
@@ -415,7 +415,7 @@ export class FileUploader {
   }
 
   /* tslint:enable */
-  private _parseHeaders(headers:string):ParsedResponseHeaders {
+  protected _parseHeaders(headers:string):ParsedResponseHeaders {
     let parsed:any = {};
     let key:any;
     let val:any;
@@ -434,33 +434,33 @@ export class FileUploader {
     return parsed;
   }
 
-  /*private _iframeTransport(item:FileItem) {
+  /*protected _iframeTransport(item:FileItem) {
    // todo: implement it later
    }*/
 
-  private _onWhenAddingFileFailed(item:FileLikeObject, filter:any, options:any):void {
+  protected _onWhenAddingFileFailed(item:FileLikeObject, filter:any, options:any):void {
     this.onWhenAddingFileFailed(item, filter, options);
   }
 
-  private _onAfterAddingFile(item:FileItem):void {
+  protected _onAfterAddingFile(item:FileItem):void {
     this.onAfterAddingFile(item);
   }
 
-  private _onAfterAddingAll(items:any):void {
+  protected _onAfterAddingAll(items:any):void {
     this.onAfterAddingAll(items);
   }
 
-  private _onBeforeUploadItem(item:FileItem):void {
+  protected _onBeforeUploadItem(item:FileItem):void {
     item._onBeforeUpload();
     this.onBeforeUploadItem(item);
   }
 
-  private _onBuildItemForm(item:FileItem, form:any):void {
+  protected _onBuildItemForm(item:FileItem, form:any):void {
     item._onBuildForm(form);
     this.onBuildItemForm(item, form);
   }
 
-  private _onProgressItem(item:FileItem, progress:any):void {
+  protected _onProgressItem(item:FileItem, progress:any):void {
     let total = this._getTotalProgress(progress);
     this.progress = total;
     item._onProgress(progress);
@@ -470,13 +470,13 @@ export class FileUploader {
   }
 
   /* tslint:disable */
-  private _onSuccessItem(item:FileItem, response:string, status:number, headers:ParsedResponseHeaders):void {
+  protected _onSuccessItem(item:FileItem, response:string, status:number, headers:ParsedResponseHeaders):void {
     item._onSuccess(response, status, headers);
     this.onSuccessItem(item, response, status, headers);
   }
 
   /* tslint:enable */
-  private _onCancelItem(item:FileItem, response:string, status:number, headers:ParsedResponseHeaders):void {
+  protected _onCancelItem(item:FileItem, response:string, status:number, headers:ParsedResponseHeaders):void {
     item._onCancel(response, status, headers);
     this.onCancelItem(item, response, status, headers);
   }


### PR DESCRIPTION
Hi. We need to take an advantage of Object Oriented Programming brought to us by Typescript. It means (almost) all classes should be extensible, and to make classes extensible we need to avoid the `private` access modifiers, since child class can't not only overrwite them in themselves but also edit any method using `private` fields or methods without copying them all. And as we all know - copying the code is something we really don't want to do :)
That's why I've replaced all `private` accessors by `protected` to allow extending of classes. It actually changes nothing in functionality, but doesn't force developers like us to maintain individual forks, so please merge it as soon as possible. Thanks in advance!
