### PR TITLE
Add promise support on filters

### DIFF
--- a/src/file-upload/file-uploader.class.ts
+++ b/src/file-upload/file-uploader.class.ts
@@ -13,7 +13,7 @@ export interface Headers {
 
 export type ParsedResponseHeaders = {[headerFieldName:string]:string};
 
-export type FilterFunction = {name:string, fn:(item?:FileLikeObject, options?:FileUploaderOptions)=>boolean};
+export type FilterFunction = {name:string, fn:(item?:FileLikeObject, options?:FileUploaderOptions)=>boolean|Promise<boolean>};
 
 export interface FileUploaderOptions {
   allowedMimeType?:Array<string>;
@@ -98,15 +98,15 @@ export class FileUploader {
       }
 
       let temp = new FileLikeObject(some);
-      if (this._isValidFile(temp, arrayOfFilters, options)) {
+      this._isValidFile(temp, arrayOfFilters, options).then(() => {
         let fileItem = new FileItem(this, some, options);
         addedFileItems.push(fileItem);
         this.queue.push(fileItem);
         this._onAfterAddingFile(fileItem);
-      } else {
+      }).catch(() => {
         let filter = arrayOfFilters[this._failFilterIndex];
         this._onWhenAddingFileFailed(temp, filter, options);
-      }
+      });
     });
     if (this.queue.length !== count) {
       this._onAfterAddingAll(addedFileItems);
@@ -400,11 +400,27 @@ export class FileUploader {
     return this.options.queueLimit === undefined || this.queue.length < this.options.queueLimit;
   }
 
-  protected _isValidFile(file:FileLikeObject, filters:FilterFunction[], options:FileUploaderOptions):boolean {
+  protected _isValidFile(file:FileLikeObject, filters:FilterFunction[], options:FileUploaderOptions): Promise<boolean> {
+    if (!filters.length) {
+      return Promise.resolve(true);
+    }
+
     this._failFilterIndex = -1;
-    return !filters.length ? true : filters.every((filter:FilterFunction) => {
-      this._failFilterIndex++;
-      return filter.fn.call(this, file, options);
+
+    return Promise.all(
+      filters.map((filter: FilterFunction) => {
+        const isValid: boolean = filter.fn.call(this, file, options);
+
+        return Promise.resolve(isValid);
+      })
+    ).then((values) => {
+      const isValid = values.every((value: boolean) => {
+        this._failFilterIndex++;
+
+        return value;
+      })
+
+      return isValid ? Promise.resolve(isValid) : Promise.reject(isValid);
     });
   }
 


### PR DESCRIPTION
Sometimes you need to do something more in your filter function (will send you another PR for that) and because of that, it would be better to have the isValid method wrapped in a Promise.

There si one catch, cause of the variable `this._failFilterIndex` we need to resolve each time, so for the users who will use promises they always need to resolve, either with true or false.

