### PR TITLE
Add rawFile in the file like object

### DIFF
--- a/src/file-upload/file-like-object.class.ts
+++ b/src/file-upload/file-like-object.class.ts
@@ -7,8 +7,10 @@ export class FileLikeObject {
   public size:any;
   public type:string;
   public name:string;
+  public rawFile:string;
 
   public constructor(fileOrInput:any) {
+    this.rawFile = fileOrInput;
     let isInput = isElement(fileOrInput);
     let fakePathOrObject = isInput ? fileOrInput.value : fileOrInput;
     let postfix = typeof fakePathOrObject === 'string' ? 'FakePath' : 'Object';


### PR DESCRIPTION
Sometimes you need more info about the uploaded file and it would be ok to have the rawFile in the `fileLikeObject` when setting a custom filter.

I need it to get the image width and height, that's why I needed promise support #648 