### PR TITLE
Adds some Fixes for AWS Support.

### DIFF
--- a/src/file-upload/file-uploader.class.ts
+++ b/src/file-upload/file-uploader.class.ts
@@ -314,7 +314,7 @@ export class FileUploader {
           let paramVal = this.options.additionalParameter[key];
           // Allow an additional parameter to include the filename
           if (paramVal.indexOf('{{file_name}}') >= 0) {
-            paramVal.replace('{{file_name}}', item.file.name);
+            paramVal = paramVal.replace('{{file_name}}', item.file.name);
           }
           sendable.append(key, paramVal);
         });

--- a/src/file-upload/file-uploader.class.ts
+++ b/src/file-upload/file-uploader.class.ts
@@ -313,7 +313,7 @@ export class FileUploader {
         Object.keys(this.options.additionalParameter).forEach((key:string) => {
           let paramVal = this.options.additionalParameter[key];
           // Allow an additional parameter to include the filename
-          if (paramVal.indexOf('{{file_name}}') >= 0) {
+          if (typeof paramVal === 'string' && paramVal.indexOf('{{file_name}}') >= 0) {
             paramVal = paramVal.replace('{{file_name}}', item.file.name);
           }
           sendable.append(key, paramVal);

--- a/src/file-upload/file-uploader.class.ts
+++ b/src/file-upload/file-uploader.class.ts
@@ -307,13 +307,20 @@ export class FileUploader {
       sendable = new FormData();
       this._onBuildItemForm(item, sendable);
 
-      sendable.append(item.alias, item._file, item.file.name);
 
+      // For AWS, Additional Parameters must come BEFORE Files
       if (this.options.additionalParameter !== undefined) {
         Object.keys(this.options.additionalParameter).forEach((key:string) => {
-          sendable.append(key, this.options.additionalParameter[key]);
+          let paramVal = this.options.additionalParameter[key];
+          // Allow an additional parameter to include the filename
+          if (paramVal.indexOf('{{file_name}}') >= 0) {
+            paramVal.replace('{{file_name}}', item.file.name);
+          }
+          sendable.append(key, paramVal);
         });
       }
+
+      sendable.append(item.alias, item._file, item.file.name);
     } else {
       sendable = item._file;
     }


### PR DESCRIPTION
AWS Requires any additional parameters to be specified BEFORE Files.
This also adds the ability to specify a {{file_name}} template in any
additional parameters to allow adding the filename to additional
parameters.

For example, you can now specify:

additionalParameter: {
	key: "path/to/uploads/{{file_name}}"
}