### PR TITLE
Added onFileDrop() event to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Easy to use Angular2 directives for files upload ([demo](http://valor-software.g
   - `fileOver` - it fires during 'over' and 'out' events for Drop Area; returns `boolean`: `true` if file is over Drop Area, `false` in case of out.
   See using in [ts demo](https://github.com/valor-software/ng2-file-upload/blob/master/demo/components/file-upload/simple-demo.ts) and
   [html demo](https://github.com/valor-software/ng2-file-upload/blob/master/demo/components/file-upload/simple-demo.html)
+  - `onFileDrop` - it fires after a file has been dropped on a Drop Area; you can pass in `$event` to get the list of files that were dropped. i.e. `(onFileDrop)="dropped($event)"`
 
 # Troubleshooting
 


### PR DESCRIPTION
In case anyone wants to use the onFileDrop event to handle the files in their own way, I've added it to the documentation. I ran into a situation where I wanted to add some custom logic around file uploading, so I added `onFileDrop()` to my element in order to grab the list of files.