### PR TITLE
Feature: Added queueMaxSizeLimit to limit the file size of the queued items.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Easy to use Angular2 directives for files upload ([demo](http://valor-software.g
   5. `formatDataFunction` - Function to modify the request body. 'DisableMultipart' must be 'true' for this function to be called.
   6. `formatDataFunctionIsAsync` - Informs if the function sent in 'formatDataFunction' is asynchronous. Defaults to false.
   7. `parametersBeforeFiles` - States if additional parameters should be appended before or after the file. Defaults to false.
+  8. `queueMaxSizeLimit` - States the maximum allowed size (in bytes) of all files in the queue that are going to be uploaded.
 
 ### Events
 

--- a/src/file-upload/file-uploader.class.ts
+++ b/src/file-upload/file-uploader.class.ts
@@ -30,6 +30,7 @@ export interface FileUploaderOptions {
   authToken?: string;
   maxFileSize?: number;
   queueLimit?: number;
+  queueMaxSizeLimit? : number;
   removeAfterUpload?: boolean;
   url?: string;
   disableMultipart?: boolean;
@@ -76,6 +77,10 @@ export class FileUploader {
     this.authTokenHeader = this.options.authTokenHeader || 'Authorization';
     this.autoUpload = this.options.autoUpload;
     this.options.filters.unshift({ name: 'queueLimit', fn: this._queueLimitFilter });
+
+    if (this.options.queueMaxSizeLimit) {
+      this.options.filters.unshift({ name: 'queueMaxSizeLimit', fn: this._queueMaxSizeLimitFilter });
+    }
 
     if (this.options.maxFileSize) {
       this.options.filters.unshift({ name: 'fileSize', fn: this._fileSizeFilter });
@@ -418,6 +423,17 @@ export class FileUploader {
 
   protected _queueLimitFilter(): boolean {
     return this.options.queueLimit === undefined || this.queue.length < this.options.queueLimit;
+  }
+
+  protected _queueMaxSizeLimitFilter(item: FileLikeObject): boolean {    
+    let queueFileSize = 0;    
+    let queueNotProcessedItems = this.queue.filter(queuedItem => !(queuedItem.isSuccess || queuedItem.isCancel || queuedItem.isError));
+    if(queueNotProcessedItems.length>0)
+    {
+      // total size of all queued items that are going to be uploaded
+      queueFileSize = queueNotProcessedItems.map(queuedItem => queuedItem.file.size).reduce((fileSizeA,fileSizeB)=> fileSizeA + fileSizeB);
+    }
+    return this.options.queueMaxSizeLimit === undefined || (queueFileSize + item.size) < this.options.queueMaxSizeLimit;
   }
 
   protected _isValidFile(file: FileLikeObject, filters: FilterFunction[], options: FileUploaderOptions): boolean {

--- a/src/spec/file-select.directive.spec.ts
+++ b/src/spec/file-select.directive.spec.ts
@@ -63,6 +63,7 @@ describe('Directive: FileSelectDirective', () => {
     expect(options.isHTML5).toBeTruthy();
     expect(options.removeAfterUpload).toBeFalsy();
     expect(options.disableMultipart).toBeFalsy();
+    expect(options.queueMaxSizeLimit).toBeUndefined();
   });
 
   it('can get filters', () => {


### PR DESCRIPTION
Added an option to limit the size of the queue. It only counts items that will be uploaded. Uploaded, failed and cancelled file sizes will be ignored.