### PR TITLE
Hide column headers when !uploader.options.isHTML5

### DIFF
--- a/demo/src/app/components/file-upload/simple-demo.html
+++ b/demo/src/app/components/file-upload/simple-demo.html
@@ -52,8 +52,8 @@
                 <thead>
                 <tr>
                     <th width="50%">Name</th>
-                    <th>Size</th>
-                    <th>Progress</th>
+                    <th *ngIf="uploader.options.isHTML5">Size</th>
+                    <th *ngIf="uploader.options.isHTML5">Progress</th>
                     <th>Status</th>
                     <th>Actions</th>
                 </tr>


### PR DESCRIPTION
In the demo, when the uploader.options.isHTML5 is false, the headers should also be hidden.