### PR TITLE
Allow additionalParameters to also be null

### DIFF
--- a/libs/ng2-file-upload/file-upload/file-uploader.class.ts
+++ b/libs/ng2-file-upload/file-upload/file-uploader.class.ts
@@ -318,7 +318,7 @@ export class FileUploader {
       }
 
       // For AWS, Additional Parameters must come BEFORE Files
-      if (this.options.additionalParameter !== undefined) {
+      if (this.options.additionalParameter) {
         Object.keys(this.options.additionalParameter).forEach((key: string) => {
           let paramVal = this.options.additionalParameter?.[ key ];
           // Allow an additional parameter to include the filename


### PR DESCRIPTION
If additionalParameters is null instead of undefined an error occurs. I don't see a reason for this so I'm hoping this change will be accepted. It took me a while to figure out what my issue is because of another issue that I have in that onErrorItem does not pass the exception on down so I had no information and had to go into debug mode to find the problem.