### PR TITLE
chore: Update to ngx-bootstrap 12.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "jest-preset-angular": "13.1.4",
         "markdown-loader": "^6.0.0",
         "ng-packagr": "17.0.2",
-        "ngx-bootstrap": "11.0.2",
+        "ngx-bootstrap": "12.0.0",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.3.9",
         "postcss-import": "14.1.0",
@@ -19356,19 +19356,19 @@
       }
     },
     "node_modules/ngx-bootstrap": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/ngx-bootstrap/-/ngx-bootstrap-11.0.2.tgz",
-      "integrity": "sha512-McvQ72XB6692Jus47jahWWwjpSCa6EtHMIqoyMewKCEHMv0ybDgVnOAdEsWKvwfulowHn7Y/jDjeiURwYJG9cQ==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/ngx-bootstrap/-/ngx-bootstrap-12.0.0.tgz",
+      "integrity": "sha512-6/Hs+FT6peMc+Y2uiOm3IawG06Jh3gLQwwKRBF0U1OMlRbpx4KIyHS9GpZtMevtZaBsCRNfHKiSxwsnvn9wx0Q==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/animations": "^16.0.0",
-        "@angular/common": "^16.0.0",
-        "@angular/core": "^16.0.0",
-        "@angular/forms": "^16.0.0",
-        "rxjs": "^6.5.3 || ^7.6.0"
+        "@angular/animations": "^17.0.0",
+        "@angular/common": "^17.0.0",
+        "@angular/core": "^17.0.0",
+        "@angular/forms": "^17.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/nice-napi": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@angular/platform-browser": "17.0.4",
     "@angular/platform-browser-dynamic": "17.0.4",
     "@nx/angular": "17.1.3",
+    "@nx/eslint": "17.1.3",
     "@nx/eslint-plugin": "17.1.3",
     "@nx/jest": "17.1.3",
     "@nx/node": "17.1.3",
@@ -78,7 +79,7 @@
     "jest-preset-angular": "13.1.4",
     "markdown-loader": "^6.0.0",
     "ng-packagr": "17.0.2",
-    "ngx-bootstrap": "11.0.2",
+    "ngx-bootstrap": "12.0.0",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.3.9",
     "postcss-import": "14.1.0",
@@ -90,8 +91,7 @@
     "ts-jest": "29.1.1",
     "ts-node": "10.9.1",
     "typescript": "5.2.2",
-    "zone.js": "0.14.2",
-    "@nx/eslint": "17.1.3"
+    "zone.js": "0.14.2"
   },
   "contributors": [
     {


### PR DESCRIPTION
`npm clean-install` was failing for me on `development` due to an issue resolving `ngx-bootstrap`

```
npm error While resolving: ngx-bootstrap@11.0.2
npm error Found: @angular/animations@17.0.4
npm error node_modules/@angular/animations
npm error   dev @angular/animations@"17.0.4" from the root project
npm error   peerOptional @angular/animations@"17.0.4" from @angular/platform-browser@17.0.4
npm error   node_modules/@angular/platform-browser
npm error     dev @angular/platform-browser@"17.0.4" from the root project
npm error     peer @angular/platform-browser@"17.0.4" from @angular/forms@17.0.4
npm error     node_modules/@angular/forms
npm error       dev @angular/forms@"17.0.4" from the root project
npm error     1 more (@angular/platform-browser-dynamic)

```

This PR proposes upgrading to `ngx-boostrap@12.0.0`, which is compatible with Angular 17.

With the proposed changes, `npm clean-install` appears to complete without failure.