### PR TITLE
fix(chore): `onFileDrop` is now correctly typed as a `FileList`

### DIFF
--- a/libs/ng2-file-upload/file-upload/file-drop.directive.ts
+++ b/libs/ng2-file-upload/file-upload/file-drop.directive.ts
@@ -7,7 +7,7 @@ export class FileDropDirective {
   @Input()  uploader?: FileUploader;
   @Output()  fileOver: EventEmitter<any> = new EventEmitter();
   // eslint-disable-next-line @angular-eslint/no-output-on-prefix
-  @Output()  onFileDrop: EventEmitter<File[]> = new EventEmitter<File[]>();
+  @Output()  onFileDrop: EventEmitter<FileList> = new EventEmitter<FileList>();
 
   protected element: ElementRef;
 
@@ -64,7 +64,7 @@ export class FileDropDirective {
     this.fileOver.emit(false);
   }
 
-  protected _getTransfer(event: any): any {
+  protected _getTransfer(event: any): DataTransfer {
     return event.dataTransfer ? event.dataTransfer : event.originalEvent.dataTransfer; // jQuery fix;
   }
 

--- a/libs/ng2-file-upload/file-upload/file-uploader.class.ts
+++ b/libs/ng2-file-upload/file-upload/file-uploader.class.ts
@@ -96,12 +96,15 @@ export class FileUploader {
     }
   }
 
-  addToQueue(files: File[], _options?: FileUploaderOptions, filters?: [] | string): void {
+  addToQueue(files: FileList, _options?: FileUploaderOptions, filters?: [] | string): void {
     let options = _options;
     const list: File[] = [];
-    for (const file of files) {
-      list.push(file);
+    // fori loop since jest tests do not have the dom.iterable implementation ready
+    // see https://github.com/jsdom/jsdom/issues/1272
+    for (let i = 0; i < files.length; i++) {
+      list.push(files[i]);
     }
+
     const arrayOfFilters = this._getFilters(filters);
     const count = this.queue.length;
     const addedFileItems: FileItem[] = [];

--- a/libs/ng2-file-upload/testing/spec/file-uploader.class.spec.ts
+++ b/libs/ng2-file-upload/testing/spec/file-uploader.class.spec.ts
@@ -17,7 +17,7 @@ describe('FileUploader: onWhenAddingFileFailed', () => {
         const uploader = new FileUploader({ url: '', maxFileSize: filterFileSize });
         const onWhenAddingFileFailed = jest.spyOn(uploader, 'onWhenAddingFileFailed');
 
-        uploader.addToQueue([file]);
+        uploader.addToQueue([file] as unknown as FileList);
 
         expect(filterFileSize).toBeGreaterThan(file.size);
         expect(onWhenAddingFileFailed).toBeCalledTimes(0);
@@ -28,7 +28,7 @@ describe('FileUploader: onWhenAddingFileFailed', () => {
         const uploader = new FileUploader({ url: '', maxFileSize: filterFileSize });
         const onWhenAddingFileFailed = jest.spyOn(uploader, 'onWhenAddingFileFailed');
 
-        uploader.addToQueue([file]);
+        uploader.addToQueue([file] as unknown as FileList);
 
         expect(filterFileSize).toBeLessThan(file.size);
         expect(onWhenAddingFileFailed).toBeCalledTimes(1);
@@ -40,7 +40,7 @@ describe('FileUploader: onWhenAddingFileFailed', () => {
         const onWhenAddingFileFailed = jest.spyOn(uploader, 'onWhenAddingFileFailed');
         const files = [file, file];
 
-        uploader.addToQueue([file, file]);
+        uploader.addToQueue([file, file] as unknown as FileList);
 
         expect(files.length).toBeLessThanOrEqual(queueLimit);
         expect(onWhenAddingFileFailed).toBeCalledTimes(0);
@@ -52,7 +52,7 @@ describe('FileUploader: onWhenAddingFileFailed', () => {
         const onWhenAddingFileFailed = jest.spyOn(uploader, 'onWhenAddingFileFailed');
         const files = [file, file];
 
-        uploader.addToQueue([file, file]);
+        uploader.addToQueue([file, file] as unknown as FileList);
 
         expect(files.length).toBeGreaterThan(queueLimit);
         expect(onWhenAddingFileFailed).toBeCalledTimes(1);
@@ -62,7 +62,7 @@ describe('FileUploader: onWhenAddingFileFailed', () => {
         const uploader = new FileUploader({ url: '', allowedFileType: ["image"] });
         const onWhenAddingFileFailed = jest.spyOn(uploader, 'onWhenAddingFileFailed');
 
-        uploader.addToQueue([file]);
+        uploader.addToQueue([file] as unknown as FileList);
 
         expect(onWhenAddingFileFailed).toBeCalledTimes(0);
     });
@@ -71,7 +71,7 @@ describe('FileUploader: onWhenAddingFileFailed', () => {
         const uploader = new FileUploader({ url: '', allowedFileType: ["doc"] });
         const onWhenAddingFileFailed = jest.spyOn(uploader, 'onWhenAddingFileFailed');
 
-        uploader.addToQueue([file]);
+        uploader.addToQueue([file] as unknown as FileList);
 
         expect(onWhenAddingFileFailed).toBeCalledTimes(1);
     });
@@ -81,7 +81,7 @@ describe('FileUploader: onWhenAddingFileFailed', () => {
         const uploader = new FileUploader({ url: '', allowedMimeType: [filterMimeType] });
         const onWhenAddingFileFailed = jest.spyOn(uploader, 'onWhenAddingFileFailed');
 
-        uploader.addToQueue([file]);
+        uploader.addToQueue([file] as unknown as FileList);
 
         expect(file.type).toBe(filterMimeType);
         expect(onWhenAddingFileFailed).toBeCalledTimes(0);
@@ -92,7 +92,7 @@ describe('FileUploader: onWhenAddingFileFailed', () => {
         const uploader = new FileUploader({ url: '', allowedMimeType: [filterMimeType] });
         const onWhenAddingFileFailed = jest.spyOn(uploader, 'onWhenAddingFileFailed');
 
-        uploader.addToQueue([file]);
+        uploader.addToQueue([file] as unknown as FileList);
 
         expect(file.type).not.toBe(filterMimeType);
         expect(onWhenAddingFileFailed).toBeCalledTimes(1);
@@ -103,7 +103,7 @@ describe('FileUploader: onWhenAddingFileFailed', () => {
         const uploader = new FileUploader({ url: '', filters: [positiveFilter] });
         const onWhenAddingFileFailed = jest.spyOn(uploader, 'onWhenAddingFileFailed');
 
-        uploader.addToQueue([file]);
+        uploader.addToQueue([file] as unknown as FileList);
 
         expect(positiveFilter.fn(new FileLikeObject(file))).toBe(true);
         expect(onWhenAddingFileFailed).toBeCalledTimes(0);
@@ -114,7 +114,7 @@ describe('FileUploader: onWhenAddingFileFailed', () => {
         const uploader = new FileUploader({ url: '', filters: [negativeFilter] });
         const onWhenAddingFileFailed = jest.spyOn(uploader, 'onWhenAddingFileFailed');
 
-        uploader.addToQueue([file]);
+        uploader.addToQueue([file] as unknown as FileList);
 
         expect(negativeFilter.fn(new FileLikeObject(file))).toBe(false);
         expect(onWhenAddingFileFailed).toBeCalledTimes(1);
@@ -134,7 +134,7 @@ describe('FileUploader: onWhenAddingFileFailed', () => {
         const onWhenAddingFileFailed = jest.spyOn(uploader, 'onWhenAddingFileFailed');
         const files = [file, file];
 
-        uploader.addToQueue(files);
+        uploader.addToQueue(files as unknown as FileList);
 
         expect(onWhenAddingFileFailed).toBeCalledTimes(files.length);
     });


### PR DESCRIPTION
Fixing https://github.com/valor-software/ng2-file-upload/issues/1240